### PR TITLE
[wip] ui: dedup chart config

### DIFF
--- a/pkg/ui/src/util/charts.ts
+++ b/pkg/ui/src/util/charts.ts
@@ -5,28 +5,32 @@ type Metric = {
   title?: string,
 };
 
-type MetricsChart = {
+// Chart representing multiple metrics.
+type MetricsChartConfig = {
   type: "metrics",
   measure: Measure,
   metrics: Metric[],
 };
 
-type NodesChart = {
+// Chart representing a single metric across multiple nodes.
+type NodesChartConfig = {
   type: "nodes",
   measure: Measure,
   metric: Metric,
 };
 
-type Chart = MetricsChart | NodesChart;
+export type ChartConfig = MetricsChartConfig | NodesChartConfig;
 
-export type ChartConfig = {
-  [key: string]: Chart,
+export type DashboardConfig = {
+  // Unique identifier for this dashboard, e.g. "nodes.overview"
+  id: string,
+  charts: ChartConfig[],
 };
 
-export function isMetricsChart(chart: Chart): chart is MetricsChart {
+export function isMetricsChart(chart: ChartConfig): chart is MetricsChartConfig {
   return chart.type === "metrics";
 }
 
-export function isNodesChart(chart: Chart): chart is NodesChart {
+export function isNodesChart(chart: ChartConfig): chart is NodesChartConfig {
   return chart.type === "nodes";
 }

--- a/pkg/ui/src/util/charts.ts
+++ b/pkg/ui/src/util/charts.ts
@@ -30,6 +30,7 @@ export type ChartDataConfig = MetricsChartConfig | NodesChartConfig;
 
 type CommonChartConfig = {
   title: string,
+  subtitle?: string,
   measure: Measure,
   sources?: string[],
   tooltip?: string | JSX.Element,
@@ -41,7 +42,7 @@ export type AxisConfig = {
   label?: string,
 };
 
-type ChartConfig = CommonChartConfig & ChartDataConfig;
+export type ChartConfig = CommonChartConfig & ChartDataConfig;
 
 export type DashboardConfig = {
   // Unique identifier for this dashboard, e.g. "nodes.overview"

--- a/pkg/ui/src/util/charts.ts
+++ b/pkg/ui/src/util/charts.ts
@@ -1,25 +1,47 @@
+import { AxisUnits } from "oss/src/views/shared/components/metricQuery";
+import { GraphDashboardProps } from "oss/src/views/cluster/containers/nodeGraphs/dashboards/dashboardUtils";
+
 export type Measure = "count" | "bytes" | "duration";
 
-type Metric = {
+export type Metric = {
   name: string,
+  sources?: string[],
   title?: string,
+  rate?: boolean,
+  nonNegativeRate?: boolean,
+  aggregateMax?: boolean,
+  aggregateMin?: boolean,
+  aggregateAvg?: boolean,
+  downsampleMax?: boolean,
+  downsampleMin?: boolean,
 };
 
 // Chart representing multiple metrics.
 type MetricsChartConfig = {
-  type: "metrics",
-  measure: Measure,
   metrics: Metric[],
 };
 
 // Chart representing a single metric across multiple nodes.
 type NodesChartConfig = {
-  type: "nodes",
-  measure: Measure,
   metric: Metric,
 };
 
-export type ChartConfig = MetricsChartConfig | NodesChartConfig;
+export type ChartDataConfig = MetricsChartConfig | NodesChartConfig;
+
+type CommonChartConfig = {
+  title: string,
+  measure: Measure,
+  sources?: string[],
+  tooltip?: string | JSX.Element,
+  axis?: AxisConfig,
+};
+
+export type AxisConfig = {
+  units?: AxisUnits,
+  label?: string,
+};
+
+type ChartConfig = CommonChartConfig & ChartDataConfig;
 
 export type DashboardConfig = {
   // Unique identifier for this dashboard, e.g. "nodes.overview"
@@ -27,10 +49,12 @@ export type DashboardConfig = {
   charts: ChartConfig[],
 };
 
-export function isMetricsChart(chart: ChartConfig): chart is MetricsChartConfig {
-  return chart.type === "metrics";
-}
+export type DashboardConfigState = (props: GraphDashboardProps) => DashboardConfig;
 
-export function isNodesChart(chart: ChartConfig): chart is NodesChartConfig {
-  return chart.type === "nodes";
-}
+// export function isMetricsChart(chart: ChartDataConfig): chart is MetricsChartConfig {
+//   return chart.type === "metrics";
+// }
+//
+// export function isNodesChart(chart: ChartDataConfig): chart is NodesChartConfig {
+//   return chart.type === "nodes";
+// }

--- a/pkg/ui/src/views/cluster/components/linegraph/index.tsx
+++ b/pkg/ui/src/views/cluster/components/linegraph/index.tsx
@@ -11,22 +11,16 @@ import {
 import { MetricsDataComponentProps } from "src/views/shared/components/metricQuery";
 import Visualization from "src/views/cluster/components/visualization";
 import { NanoToMilli } from "src/util/convert";
-import { AxisConfig, Metric } from "oss/src/util/charts";
+import { ChartConfig } from "oss/src/util/charts";
 
 type TSDatapoint = protos.cockroach.ts.tspb.TimeSeriesDatapoint$Properties;
 
 interface LineGraphProps extends MetricsDataComponentProps {
-  title?: string;
-  subtitle?: string;
-  legend?: boolean;
-  xAxis?: boolean;
-  tooltip?: React.ReactNode;
+  config: ChartConfig;
   hoverOn?: typeof hoverOn;
   hoverOff?: typeof hoverOff;
   hoverState?: HoverState;
   chartKey?: string;
-  metrics: Metric[];
-  axis: AxisConfig;
 }
 
 // Find which data point is closest to a specific time.
@@ -140,7 +134,14 @@ export class LineGraph extends React.Component<LineGraphProps, {}> {
       }
 
       ConfigureLineChart(
-        this.chart, this.graphEl, this.props.metrics, this.props.axis, this.props.data, this.props.timeInfo, hoverTime, thisChart,
+        this.chart,
+        this.graphEl,
+        this.props.config.metrics || [this.props.config.metric],
+        this.props.config.axis,
+        this.props.data,
+        this.props.timeInfo,
+        hoverTime,
+        thisChart,
       );
     }
   }
@@ -163,7 +164,8 @@ export class LineGraph extends React.Component<LineGraphProps, {}> {
   }
 
   render() {
-    const { title, subtitle, tooltip, data } = this.props;
+    const { config, data } = this.props;
+    const { title, subtitle, tooltip } = config;
 
     return <Visualization title={title} subtitle={subtitle} tooltip={tooltip} loading={!data} >
       <div className="linegraph">

--- a/pkg/ui/src/views/cluster/containers/detailsTooltip/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/detailsTooltip/index.tsx
@@ -8,7 +8,7 @@ import { hoverStateSelector, HoverState } from "src/redux/hover";
 import { MetricQuerySet } from "src/redux/metrics";
 import { nodesSummarySelector, NodesSummary } from "src/redux/nodes";
 import { AdminUIState } from "src/redux/state";
-import {ChartConfig, isMetricsChart, isNodesChart, Measure} from "src/util/charts";
+import {ChartDataConfig, isMetricsChart, isNodesChart, Measure} from "src/util/charts";
 import { NanoToMilli } from "src/util/convert";
 import { Bytes, Count, Duration } from "src/util/format";
 
@@ -62,7 +62,7 @@ const dashboards = [
   storageCharts,
 ];
 
-const charts: { [key: string]: ChartConfig } = {};
+const charts: { [key: string]: ChartDataConfig } = {};
 dashboards.forEach((dashboard) => {
   dashboard.charts.forEach((chart, idx) => {
     charts[`${dashboard.id}.${idx}`] = chart;

--- a/pkg/ui/src/views/cluster/containers/detailsTooltip/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/detailsTooltip/index.tsx
@@ -8,7 +8,7 @@ import { hoverStateSelector, HoverState } from "src/redux/hover";
 import { MetricQuerySet } from "src/redux/metrics";
 import { nodesSummarySelector, NodesSummary } from "src/redux/nodes";
 import { AdminUIState } from "src/redux/state";
-import { ChartConfig, isMetricsChart, isNodesChart, Measure } from "src/util/charts";
+import {ChartConfig, isMetricsChart, isNodesChart, Measure} from "src/util/charts";
 import { NanoToMilli } from "src/util/convert";
 import { Bytes, Count, Duration } from "src/util/format";
 
@@ -51,8 +51,7 @@ function getFormatter(m: Measure): Formatter {
   }
 }
 
-const charts: ChartConfig = _.assign(
-  {},
+const dashboards = [
   distributedCharts,
   overviewCharts,
   queuesCharts,
@@ -61,7 +60,14 @@ const charts: ChartConfig = _.assign(
   runtimeCharts,
   sqlCharts,
   storageCharts,
-);
+];
+
+const charts: { [key: string]: ChartConfig } = {};
+dashboards.forEach((dashboard) => {
+  dashboard.charts.forEach((chart, idx) => {
+    charts[`${dashboard.id}.${idx}`] = chart;
+  });
+});
 
 class DetailsTooltip extends React.Component<DetailsTooltipProps, {}> {
   render() {

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/distributed.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/distributed.tsx
@@ -3,66 +3,69 @@ import _ from "lodash";
 
 import { LineGraph } from "src/views/cluster/components/linegraph";
 import { Metric, Axis, AxisUnits } from "src/views/shared/components/metricQuery";
-import { ChartConfig } from "src/util/charts";
+import { DashboardConfig } from "src/util/charts";
 
 import { GraphDashboardProps, nodeAddress } from "./dashboardUtils";
 
-export const charts: ChartConfig = {
-  "nodes.distributed.0": {
-    type: "metrics",
-    measure: "count",
-    metrics: [
-      { name: "cr.node.distsender.batches", title: "Batches" },
-      { name: "cr.node.distsender.batches.partial", title: "Partial Batches" },
-    ],
-  },
-  "nodes.distributed.1": {
-    type: "metrics",
-    measure: "count",
-    metrics: [
-      { name: "cr.node.distsender.rpc.sent", title: "RPCs Sent" },
-      { name: "cr.node.distsender.rpc.sent.local", title: "Local Fast-path" },
-    ],
-  },
-  "nodes.distributed.2": {
-    type: "metrics",
-    measure: "count",
-    metrics: [
-      { name: "cr.node.distsender.rpc.sent.sendnexttimeout", title: "RPC Timeouts" },
-      { name: "cr.node.distsender.rpc.sent.nextreplicaerror", title: "Replica Errors" },
-      { name: "cr.node.distsender.errors.notleaseholder", title: "Not Leaseholder Errors" },
-    ],
-  },
-  "nodes.distributed.3": {
-    type: "metrics",
-    measure: "count",
-    metrics: [
-      { name: "cr.node.txn.commits", title: "Committed" },
-      { name: "cr.node.txn.commits1PC", title: "Fast-path Committed" },
-      { name: "cr.node.txn.aborts", title: "Aborted" },
-      { name: "cr.node.txn.abandons", title: "Abandoned" },
-    ],
-  },
-  "nodes.distributed.4": {
-    type: "metrics",
-    measure: "count",
-    metrics: [
-      { name: "cr.node.txn.restarts.writetooold", title: "Write Too Old" },
-      { name: "cr.node.txn.restarts.deleterange", title: "Forwarded Timestamp (delete range)" },
-      { name: "cr.node.txn.restarts.serializable", title: "Forwarded Timestamp (iso=serializable)" },
-      { name: "cr.node.txn.restarts.possiblereplay", title: "Possible Replay" },
-    ],
-  },
-  "nodes.distributed.5": {
-    type: "nodes",
-    measure: "duration",
-    metric: { name: "cr.node.txn.durations-p99" },
-  },
-  "nodes.distributed.6": {
-    type: "nodes",
-    measure: "duration",
-    metric: { name: "cr.node.txn.durations-p90" },
-  },
+export const charts: DashboardConfig = {
+  id: "nodes.distributed",
+  charts: [
+    {
+      type: "metrics",
+      measure: "count",
+      metrics: [
+        { name: "cr.node.distsender.batches", title: "Batches" },
+        { name: "cr.node.distsender.batches.partial", title: "Partial Batches" },
+      ],
+    },
+    {
+      type: "metrics",
+      measure: "count",
+      metrics: [
+        { name: "cr.node.distsender.rpc.sent", title: "RPCs Sent" },
+        { name: "cr.node.distsender.rpc.sent.local", title: "Local Fast-path" },
+      ],
+    },
+    {
+      type: "metrics",
+      measure: "count",
+      metrics: [
+        { name: "cr.node.distsender.rpc.sent.sendnexttimeout", title: "RPC Timeouts" },
+        { name: "cr.node.distsender.rpc.sent.nextreplicaerror", title: "Replica Errors" },
+        { name: "cr.node.distsender.errors.notleaseholder", title: "Not Leaseholder Errors" },
+      ],
+    },
+    {
+      type: "metrics",
+      measure: "count",
+      metrics: [
+        { name: "cr.node.txn.commits", title: "Committed" },
+        { name: "cr.node.txn.commits1PC", title: "Fast-path Committed" },
+        { name: "cr.node.txn.aborts", title: "Aborted" },
+        { name: "cr.node.txn.abandons", title: "Abandoned" },
+      ],
+    },
+    {
+      type: "metrics",
+      measure: "count",
+      metrics: [
+        { name: "cr.node.txn.restarts.writetooold", title: "Write Too Old" },
+        { name: "cr.node.txn.restarts.deleterange", title: "Forwarded Timestamp (delete range)" },
+        { name: "cr.node.txn.restarts.serializable", title: "Forwarded Timestamp (iso=serializable)" },
+        { name: "cr.node.txn.restarts.possiblereplay", title: "Possible Replay" },
+      ],
+    },
+    {
+      type: "nodes",
+      measure: "duration",
+      metric: { name: "cr.node.txn.durations-p99" },
+    },
+    {
+      type: "nodes",
+      measure: "duration",
+      metric: { name: "cr.node.txn.durations-p90" },
+    },
+  ],
 };
 
 export default function (props: GraphDashboardProps) {

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
@@ -4,41 +4,44 @@ import _ from "lodash";
 import docsURL from "src/util/docs";
 import { LineGraph } from "src/views/cluster/components/linegraph";
 import { Metric, Axis, AxisUnits } from "src/views/shared/components/metricQuery";
-import { ChartConfig } from "src/util/charts";
+import { DashboardConfig } from "src/util/charts";
 
 import { GraphDashboardProps, nodeAddress, storeIDsForNode } from "./dashboardUtils";
 
-export const charts: ChartConfig = {
-  "nodes.overview.0": {
-    type: "metrics",
-    measure: "count",
-    metrics: [
-      { name: "cr.node.sql.select.count", title: "Total Reads" },
-      { name: "cr.node.sql.distsql.select.count", title: "DistSQL Reads" },
-      { name: "cr.node.sql.update.count", title: "Updates" },
-      { name: "cr.node.sql.insert.count", title: "Inserts" },
-      { name: "cr.node.sql.delete.count", title: "Deletes" },
-    ],
-  },
-  "nodes.overview.1": {
-    type: "nodes",
-    measure: "duration",
-    metric: { name: "cr.node.sql.service.latency-p99" },
-  },
-  "nodes.overview.2": {
-    type: "nodes",
-    measure: "count",
-    metric: { name: "cr.store.replicas" },
-  },
-  "nodes.overview.3": {
-    type: "metrics",
-    measure: "bytes",
-    metrics: [
-      { name: "cr.store.capacity", title: "Capacity" },
-      { name: "cr.store.capacity.available", title: "Available" },
-      { name: "cr.store.capacity.used", title: "Used" },
-    ],
-  },
+export const charts: DashboardConfig = {
+  id: "nodes.overview",
+  charts: [
+    {
+      type: "metrics",
+      measure: "count",
+      metrics: [
+        { name: "cr.node.sql.select.count", title: "Total Reads" },
+        { name: "cr.node.sql.distsql.select.count", title: "DistSQL Reads" },
+        { name: "cr.node.sql.update.count", title: "Updates" },
+        { name: "cr.node.sql.insert.count", title: "Inserts" },
+        { name: "cr.node.sql.delete.count", title: "Deletes" },
+      ],
+    },
+    {
+      type: "nodes",
+      measure: "duration",
+      metric: { name: "cr.node.sql.service.latency-p99" },
+    },
+    {
+      type: "nodes",
+      measure: "count",
+      metric: { name: "cr.store.replicas" },
+    },
+    {
+      type: "metrics",
+      measure: "bytes",
+      metrics: [
+        { name: "cr.store.capacity", title: "Capacity" },
+        { name: "cr.store.capacity.available", title: "Available" },
+        { name: "cr.store.capacity.used", title: "Used" },
+      ],
+    },
+  ],
 };
 
 export default function (props: GraphDashboardProps) {

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/queues.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/queues.tsx
@@ -2,100 +2,103 @@ import React from "react";
 
 import { LineGraph } from "src/views/cluster/components/linegraph";
 import { Metric, Axis, AxisUnits } from "src/views/shared/components/metricQuery";
-import { ChartConfig } from "src/util/charts";
+import { DashboardConfig } from "src/util/charts";
 
 import { GraphDashboardProps } from "./dashboardUtils";
 
-export const charts: ChartConfig = {
-  "nodes.queues.0": {
-    type: "metrics",
-    measure: "count",
-    metrics: [
-      { name: "cr.store.queue.gc.process.failure", title: "GC" },
-      { name: "cr.store.queue.replicagc.process.failure", title: "Replica GC" },
-      { name: "cr.store.queue.replicate.process.failure", title: "Replication" },
-      { name: "cr.store.queue.split.process.failure", title: "Split" },
-      { name: "cr.store.queue.consistency.process.failure", title: "Consistency" },
-      { name: "cr.store.queue.raftlog.process.failure", title: "Raft Log" },
-      { name: "cr.store.queue.tsmaintenance.process.failure", title: "Time Series Maintenance" },
-    ],
-  },
-  "nodes.queues.1": {
-    type: "metrics",
-    measure: "duration",
-    metrics: [
-      { name: "cr.store.queue.gc.processingnanos", title: "GC" },
-      { name: "cr.store.queue.replicagc.processingnanos", title: "Replica GC" },
-      { name: "cr.store.queue.replicate.processingnanos", title: "Replication" },
-      { name: "cr.store.queue.split.processingnanos", title: "Split" },
-      { name: "cr.store.queue.consistency.processingnanos", title: "Consistency" },
-      { name: "cr.store.queue.raftlog.processingnanos", title: "Raft Log" },
-      { name: "cr.store.queue.tsmaintenance.processingnanos", title: "Time Series Maintenance" },
-    ],
-  },
-  "nodes.queues.2": {
-    type: "metrics",
-    measure: "count",
-    metrics: [
-      { name: "cr.store.queue.replicagc.process.success", title: "Successful Actions / sec" },
-      { name: "cr.store.queue.replicagc.pending", title: "Pending Actions" },
-      { name: "cr.store.queue.replicagc.removereplica", title: "Replicas Removed / sec" },
-    ],
-  },
-  "nodes.queues.3": {
-    type: "metrics",
-    measure: "count",
-    metrics: [
-      { name: "cr.store.queue.replicate.process.success", title: "Successful Actions / sec" },
-      { name: "cr.store.queue.replicate.pending", title: "Pending Actions" },
-      { name: "cr.store.queue.replicate.addreplica", title: "Replicas Added / sec" },
-      { name: "cr.store.queue.replicate.removereplica", title: "Replicas Removed / sec" },
-      { name: "cr.store.queue.replicate.removedeadreplica", title: "Dead Replicas Removed / sec" },
-      { name: "cr.store.queue.replicate.rebalancereplica", title: "Replicas Rebalanced / sec" },
-      { name: "cr.store.queue.replicate.transferlease", title: "Leases Transferred / sec" },
-      { name: "cr.store.queue.replicate.purgatory", title: "Replicas in Purgatory" },
-    ],
-  },
-  "nodes.queues.4": {
-    type: "metrics",
-    measure: "count",
-    metrics: [
-      { name: "cr.store.queue.split.process.success", title: "Successful Actions / sec" },
-      { name: "cr.store.queue.split.pending", title: "Pending Actions" },
-    ],
-  },
-  "nodes.queues.5": {
-    type: "metrics",
-    measure: "count",
-    metrics: [
-      { name: "cr.store.queue.gc.process.success", title: "Successful Actions / sec" },
-      { name: "cr.store.queue.gc.pending", title: "Pending Actions" },
-    ],
-  },
-  "nodes.queues.6": {
-    type: "metrics",
-    measure: "count",
-    metrics: [
-      { name: "cr.store.queue.raftlog.process.success", title: "Successful Actions / sec" },
-      { name: "cr.store.queue.raftlog.pending", title: "Pending Actions" },
-    ],
-  },
-  "nodes.queues.7": {
-    type: "metrics",
-    measure: "count",
-    metrics: [
-      { name: "cr.store.queue.consistency.process.success", title: "Successful Actions / sec" },
-      { name: "cr.store.queue.consistency.pending", title: "Pending Actions" },
-    ],
-  },
-  "nodes.queues.8": {
-    type: "metrics",
-    measure: "count",
-    metrics: [
-      { name: "cr.store.queue.tsmaintenance.process.success", title: "Successful Actions / sec" },
-      { name: "cr.store.queue.tsmaintenance.pending", title: "Pending Actions" },
-    ],
-  },
+export const charts: DashboardConfig = {
+  id: "nodes.queues",
+  charts: [
+    {
+      type: "metrics",
+      measure: "count",
+      metrics: [
+        { name: "cr.store.queue.gc.process.failure", title: "GC" },
+        { name: "cr.store.queue.replicagc.process.failure", title: "Replica GC" },
+        { name: "cr.store.queue.replicate.process.failure", title: "Replication" },
+        { name: "cr.store.queue.split.process.failure", title: "Split" },
+        { name: "cr.store.queue.consistency.process.failure", title: "Consistency" },
+        { name: "cr.store.queue.raftlog.process.failure", title: "Raft Log" },
+        { name: "cr.store.queue.tsmaintenance.process.failure", title: "Time Series Maintenance" },
+      ],
+    },
+    {
+      type: "metrics",
+      measure: "duration",
+      metrics: [
+        { name: "cr.store.queue.gc.processingnanos", title: "GC" },
+        { name: "cr.store.queue.replicagc.processingnanos", title: "Replica GC" },
+        { name: "cr.store.queue.replicate.processingnanos", title: "Replication" },
+        { name: "cr.store.queue.split.processingnanos", title: "Split" },
+        { name: "cr.store.queue.consistency.processingnanos", title: "Consistency" },
+        { name: "cr.store.queue.raftlog.processingnanos", title: "Raft Log" },
+        { name: "cr.store.queue.tsmaintenance.processingnanos", title: "Time Series Maintenance" },
+      ],
+    },
+    {
+      type: "metrics",
+      measure: "count",
+      metrics: [
+        { name: "cr.store.queue.replicagc.process.success", title: "Successful Actions / sec" },
+        { name: "cr.store.queue.replicagc.pending", title: "Pending Actions" },
+        { name: "cr.store.queue.replicagc.removereplica", title: "Replicas Removed / sec" },
+      ],
+    },
+    {
+      type: "metrics",
+      measure: "count",
+      metrics: [
+        { name: "cr.store.queue.replicate.process.success", title: "Successful Actions / sec" },
+        { name: "cr.store.queue.replicate.pending", title: "Pending Actions" },
+        { name: "cr.store.queue.replicate.addreplica", title: "Replicas Added / sec" },
+        { name: "cr.store.queue.replicate.removereplica", title: "Replicas Removed / sec" },
+        { name: "cr.store.queue.replicate.removedeadreplica", title: "Dead Replicas Removed / sec" },
+        { name: "cr.store.queue.replicate.rebalancereplica", title: "Replicas Rebalanced / sec" },
+        { name: "cr.store.queue.replicate.transferlease", title: "Leases Transferred / sec" },
+        { name: "cr.store.queue.replicate.purgatory", title: "Replicas in Purgatory" },
+      ],
+    },
+    {
+      type: "metrics",
+      measure: "count",
+      metrics: [
+        { name: "cr.store.queue.split.process.success", title: "Successful Actions / sec" },
+        { name: "cr.store.queue.split.pending", title: "Pending Actions" },
+      ],
+    },
+    {
+      type: "metrics",
+      measure: "count",
+      metrics: [
+        { name: "cr.store.queue.gc.process.success", title: "Successful Actions / sec" },
+        { name: "cr.store.queue.gc.pending", title: "Pending Actions" },
+      ],
+    },
+    {
+      type: "metrics",
+      measure: "count",
+      metrics: [
+        { name: "cr.store.queue.raftlog.process.success", title: "Successful Actions / sec" },
+        { name: "cr.store.queue.raftlog.pending", title: "Pending Actions" },
+      ],
+    },
+    {
+      type: "metrics",
+      measure: "count",
+      metrics: [
+        { name: "cr.store.queue.consistency.process.success", title: "Successful Actions / sec" },
+        { name: "cr.store.queue.consistency.pending", title: "Pending Actions" },
+      ],
+    },
+    {
+      type: "metrics",
+      measure: "count",
+      metrics: [
+        { name: "cr.store.queue.tsmaintenance.process.success", title: "Successful Actions / sec" },
+        { name: "cr.store.queue.tsmaintenance.pending", title: "Pending Actions" },
+      ],
+    },
+  ],
 };
 
 export default function (props: GraphDashboardProps) {

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
@@ -3,70 +3,73 @@ import _ from "lodash";
 
 import { LineGraph } from "src/views/cluster/components/linegraph";
 import { Metric, Axis, AxisUnits } from "src/views/shared/components/metricQuery";
-import { ChartConfig } from "src/util/charts";
+import { DashboardConfig } from "src/util/charts";
 
 import { GraphDashboardProps, nodeAddress, storeIDsForNode } from "./dashboardUtils";
 
-export const charts: ChartConfig = {
-  "nodes.replication.0": {
-    type: "metrics",
-    measure: "count",
-    metrics: [
-      { name: "cr.store.ranges", title: "Ranges" },
-      { name: "cr.store.replicas.leaders", title: "Leaders" },
-      { name: "cr.store.replicas.leaseholders", title: "Lease Holders" },
-      { name: "cr.store.replicas.leaders_not_leaseholders", title: "Leaders w/o Lease" },
-      { name: "cr.store.ranges.unavailable", title: "Unavailable" },
-      { name: "cr.store.ranges.underreplicated", title: "Under-replicated" },
-    ],
-  },
-  "nodes.replication.1": {
-    type: "nodes",
-    measure: "count",
-    metric: { name: "cr.store.replicas" },
-  },
-  "nodes.replication.2": {
-    type: "nodes",
-    measure: "count",
-    metric: { name: "cr.store.replicas.leaseholders" },
-  },
-  "nodes.replication.3": {
-    type: "nodes",
-    measure: "bytes",
-    metric: { name: "cr.store.totalbytes" },
-  },
-  "nodes.replication.4": {
-    type: "nodes",
-    measure: "count",
-    metric: { name: "cr.store.rebalancing.writespersecond" },
-  },
-  "nodes.replication.5": {
-    type: "metrics",
-    measure: "count",
-    metrics: [
-      { name: "cr.store.replicas", title: "Replicas" },
-      { name: "cr.store.replicas.quiescent", title: "Quiescent" },
-    ],
-  },
-  "nodes.replication.6": {
-    type: "metrics",
-    measure: "count",
-    metrics: [
-      { name: "cr.store.range.splits", title: "Splits" },
-      { name: "cr.store.range.adds", title: "Adds" },
-      { name: "cr.store.range.removes", title: "Removes" },
-    ],
-  },
-  "nodes.replication.7": {
-    type: "metrics",
-    measure: "count",
-    metrics: [
-      { name: "cr.store.range.snapshots.generated", title: "Generated" },
-      { name: "cr.store.range.snapshots.normal-applied", title: "Normal-applied" },
-      { name: "cr.store.range.snapshots.preemptive-applied", title: "Preemptive-applied" },
-      { name: "cr.store.replicas.reserved", title: "Reserved" },
-    ],
-  },
+export const charts: DashboardConfig = {
+  id: "nodes.replication",
+  charts: [
+    {
+      type: "metrics",
+      measure: "count",
+      metrics: [
+        { name: "cr.store.ranges", title: "Ranges" },
+        { name: "cr.store.replicas.leaders", title: "Leaders" },
+        { name: "cr.store.replicas.leaseholders", title: "Lease Holders" },
+        { name: "cr.store.replicas.leaders_not_leaseholders", title: "Leaders w/o Lease" },
+        { name: "cr.store.ranges.unavailable", title: "Unavailable" },
+        { name: "cr.store.ranges.underreplicated", title: "Under-replicated" },
+      ],
+    },
+    {
+      type: "nodes",
+      measure: "count",
+      metric: { name: "cr.store.replicas" },
+    },
+    {
+      type: "nodes",
+      measure: "count",
+      metric: { name: "cr.store.replicas.leaseholders" },
+    },
+    {
+      type: "nodes",
+      measure: "bytes",
+      metric: { name: "cr.store.totalbytes" },
+    },
+    {
+      type: "nodes",
+      measure: "count",
+      metric: { name: "cr.store.rebalancing.writespersecond" },
+    },
+    {
+      type: "metrics",
+      measure: "count",
+      metrics: [
+        { name: "cr.store.replicas", title: "Replicas" },
+        { name: "cr.store.replicas.quiescent", title: "Quiescent" },
+      ],
+    },
+    {
+      type: "metrics",
+      measure: "count",
+      metrics: [
+        { name: "cr.store.range.splits", title: "Splits" },
+        { name: "cr.store.range.adds", title: "Adds" },
+        { name: "cr.store.range.removes", title: "Removes" },
+      ],
+    },
+    {
+      type: "metrics",
+      measure: "count",
+      metrics: [
+        { name: "cr.store.range.snapshots.generated", title: "Generated" },
+        { name: "cr.store.range.snapshots.normal-applied", title: "Normal-applied" },
+        { name: "cr.store.range.snapshots.preemptive-applied", title: "Preemptive-applied" },
+        { name: "cr.store.replicas.reserved", title: "Reserved" },
+      ],
+    },
+  ],
 };
 
 export default function (props: GraphDashboardProps) {

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/requests.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/requests.tsx
@@ -2,39 +2,42 @@ import React from "react";
 
 import { LineGraph } from "src/views/cluster/components/linegraph";
 import { Metric, Axis } from "src/views/shared/components/metricQuery";
-import { ChartConfig } from "src/util/charts";
+import { DashboardConfig } from "src/util/charts";
 
 import { GraphDashboardProps } from "./dashboardUtils";
 
-export const charts: ChartConfig = {
-  "nodes.requests.0": {
-    type: "metrics",
-    measure: "count",
-    metrics: [
-      { name: "cr.node.requests.slow.distsender", title: "Slow Distsender Requests" },
-    ],
-  },
-  "nodes.requests.1": {
-    type: "metrics",
-    measure: "count",
-    metrics: [
-      { name: "cr.store.requests.slow.raft", title: "Slow Raft Proposals" },
-    ],
-  },
-  "nodes.requests.2": {
-    type: "metrics",
-    measure: "count",
-    metrics: [
-      { name: "cr.store.requests.slow.lease", title: "Slow Lease Acquisitions" },
-    ],
-  },
-  "nodes.requests.3": {
-    type: "metrics",
-    measure: "count",
-    metrics: [
-      { name: "cr.store.requests.slow.commandqueue", title: "Slow Command Queue Entries" },
-    ],
-  },
+export const charts: DashboardConfig = {
+  id: "nodes.requests",
+  charts: [
+    {
+      type: "metrics",
+      measure: "count",
+      metrics: [
+        { name: "cr.node.requests.slow.distsender", title: "Slow Distsender Requests" },
+      ],
+    },
+    {
+      type: "metrics",
+      measure: "count",
+      metrics: [
+        { name: "cr.store.requests.slow.raft", title: "Slow Raft Proposals" },
+      ],
+    },
+    {
+      type: "metrics",
+      measure: "count",
+      metrics: [
+        { name: "cr.store.requests.slow.lease", title: "Slow Lease Acquisitions" },
+      ],
+    },
+    {
+      type: "metrics",
+      measure: "count",
+      metrics: [
+        { name: "cr.store.requests.slow.commandqueue", title: "Slow Command Queue Entries" },
+      ],
+    },
+  ],
 };
 
 export default function (props: GraphDashboardProps) {

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/runtime.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/runtime.tsx
@@ -2,59 +2,62 @@ import React from "react";
 
 import { LineGraph } from "src/views/cluster/components/linegraph";
 import { Metric, Axis, AxisUnits } from "src/views/shared/components/metricQuery";
-import { ChartConfig } from "src/util/charts";
+import { DashboardConfig } from "src/util/charts";
 
 import { GraphDashboardProps } from "./dashboardUtils";
 
-export const charts: ChartConfig = {
-  "nodes.runtime.0": {
-    type: "metrics",
-    measure: "count",
-    metrics: [
-      { name: "cr.node.liveness.livenodes", title: "Live Nodes" },
-    ],
-  },
-  "nodes.runtime.1": {
-    type: "metrics",
-    measure: "bytes",
-    metrics: [
-      { name: "cr.node.sys.rss", title: "Total memory (RSS)" },
-      { name: "cr.node.sys.go.allocbytes", title: "Go Allocated" },
-      { name: "cr.node.sys.go.totalbytes", title: "Go Total" },
-      { name: "cr.node.sys.cgo.allocbytes", title: "CGo Allocated" },
-      { name: "cr.node.sys.cgo.totalbytes", title: "CGo Total" },
-    ],
-  },
-  "nodes.runtime.2": {
-    type: "metrics",
-    measure: "count",
-    metrics: [
-      { name: "cr.node.sys.goroutines", title: "Goroutine Count" },
-    ],
-  },
-  "nodes.runtime.3": {
-    type: "metrics",
-    measure: "count",
-    metrics: [
-      { name: "cr.node.sys.gc.count", title: "GC Runs" },
-    ],
-  },
-  "nodes.runtime.4": {
-    type: "metrics",
-    measure: "count",
-    metrics: [
-      { name: "cr.node.sys.gc.pause.ns", title: "GC Pause Time" },
-    ],
-  },
-  "nodes.runtime.5": {
-    type: "metrics",
-    measure: "count",
-    metrics: [
-      { name: "cr.node.sys.cpu.user.ns", title: "User CPU Time" },
-      { name: "cr.node.sys.cpu.sys.ns", title: "Sys CPU Time" },
-      { name: "cr.node.sys.gc.pause.ns", title: "GC Pause Time" },
-    ],
-  },
+export const charts: DashboardConfig = {
+  id: "nodes.runtime",
+  charts: [
+    {
+      type: "metrics",
+      measure: "count",
+      metrics: [
+        { name: "cr.node.liveness.livenodes", title: "Live Nodes" },
+      ],
+    },
+    {
+      type: "metrics",
+      measure: "bytes",
+      metrics: [
+        { name: "cr.node.sys.rss", title: "Total memory (RSS)" },
+        { name: "cr.node.sys.go.allocbytes", title: "Go Allocated" },
+        { name: "cr.node.sys.go.totalbytes", title: "Go Total" },
+        { name: "cr.node.sys.cgo.allocbytes", title: "CGo Allocated" },
+        { name: "cr.node.sys.cgo.totalbytes", title: "CGo Total" },
+      ],
+    },
+    {
+      type: "metrics",
+      measure: "count",
+      metrics: [
+        { name: "cr.node.sys.goroutines", title: "Goroutine Count" },
+      ],
+    },
+    {
+      type: "metrics",
+      measure: "count",
+      metrics: [
+        { name: "cr.node.sys.gc.count", title: "GC Runs" },
+      ],
+    },
+    {
+      type: "metrics",
+      measure: "count",
+      metrics: [
+        { name: "cr.node.sys.gc.pause.ns", title: "GC Pause Time" },
+      ],
+    },
+    {
+      type: "metrics",
+      measure: "count",
+      metrics: [
+        { name: "cr.node.sys.cpu.user.ns", title: "User CPU Time" },
+        { name: "cr.node.sys.cpu.sys.ns", title: "Sys CPU Time" },
+        { name: "cr.node.sys.gc.pause.ns", title: "GC Pause Time" },
+      ],
+    },
+  ],
 };
 
 export default function (props: GraphDashboardProps) {

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
@@ -3,96 +3,99 @@ import _ from "lodash";
 
 import { LineGraph } from "src/views/cluster/components/linegraph";
 import { Metric, Axis, AxisUnits } from "src/views/shared/components/metricQuery";
-import { ChartConfig } from "src/util/charts";
+import { DashboardConfig } from "src/util/charts";
 
 import { GraphDashboardProps, nodeAddress } from "./dashboardUtils";
 
-export const charts: ChartConfig = {
-  "nodes.sql.0": {
-    type: "metrics",
-    measure: "count",
-    metrics: [
-      { name: "cr.node.sql.conns", title: "Client Connections" },
-    ],
-  },
-  "nodes.sql.1": {
-    type: "metrics",
-    measure: "bytes",
-    metrics: [
-      { name: "cr.node.sql.bytesin", title: "Bytes In" },
-      { name: "cr.node.sql.bytesout", title: "Bytes Out" },
-    ],
-  },
-  "nodes.sql.2": {
-    type: "metrics",
-    measure: "count",
-    metrics: [
-      { name: "cr.node.sql.select.count", title: "Total Reads" },
-      { name: "cr.node.sql.distsql.select.count", title: "DistSQL Reads" },
-      { name: "cr.node.sql.update.count", title: "Updates" },
-      { name: "cr.node.sql.insert.count", title: "Inserts" },
-      { name: "cr.node.sql.delete.count", title: "Deletes" },
-    ],
-  },
-  "nodes.sql.3": {
-    type: "metrics",
-    measure: "count",
-    metrics: [
-      { name: "cr.node.sql.distsql.queries.active", title: "Active Queries" },
-    ],
-  },
-  "nodes.sql.4": {
-    type: "nodes",
-    measure: "count",
-    metric: { name: "cr.node.sql.distsql.flows.active" },
-  },
-  "nodes.sql.5": {
-    type: "nodes",
-    measure: "duration",
-    metric: { name: "cr.node.sql.service.latency-p99" },
-  },
-  "nodes.sql.6": {
-    type: "nodes",
-    measure: "duration",
-    metric: { name: "cr.node.sql.service.latency-p90" },
-  },
-  "nodes.sql.7": {
-    type: "nodes",
-    measure: "duration",
-    metric: { name: "cr.node.sql.distsql.service.latency-p99" },
-  },
-  "nodes.sql.8": {
-    type: "nodes",
-    measure: "duration",
-    metric: { name: "cr.node.sql.distsql.service.latency-p90" },
-  },
-  "nodes.sql.9": {
-    type: "nodes",
-    measure: "duration",
-    metric: { name: "cr.node.exec.latency-p99" },
-  },
-  "nodes.sql.10": {
-    type: "nodes",
-    measure: "duration",
-    metric: { name: "cr.node.exec.latency-p90" },
-  },
-  "nodes.sql.11": {
-    type: "metrics",
-    measure: "count",
-    metrics: [
-      { name: "cr.node.sql.txn.begin.count", title: "Begin" },
-      { name: "cr.node.sql.txn.commit.count", title: "Commits" },
-      { name: "cr.node.sql.txn.rollback.count", title: "Rollbacks" },
-      { name: "cr.node.sql.txn.abort.count", title: "Aborts" },
-    ],
-  },
-  "nodes.sql.12": {
-    type: "metrics",
-    measure: "count",
-    metrics: [
-      { name: "cr.node.sql.ddl.count", title: "DDL Statements" },
-    ],
-  },
+export const charts: DashboardConfig = {
+  id: "nodes.sql",
+  charts: [
+    {
+      type: "metrics",
+      measure: "count",
+      metrics: [
+        { name: "cr.node.sql.conns", title: "Client Connections" },
+      ],
+    },
+    {
+      type: "metrics",
+      measure: "bytes",
+      metrics: [
+        { name: "cr.node.sql.bytesin", title: "Bytes In" },
+        { name: "cr.node.sql.bytesout", title: "Bytes Out" },
+      ],
+    },
+    {
+      type: "metrics",
+      measure: "count",
+      metrics: [
+        { name: "cr.node.sql.select.count", title: "Total Reads" },
+        { name: "cr.node.sql.distsql.select.count", title: "DistSQL Reads" },
+        { name: "cr.node.sql.update.count", title: "Updates" },
+        { name: "cr.node.sql.insert.count", title: "Inserts" },
+        { name: "cr.node.sql.delete.count", title: "Deletes" },
+      ],
+    },
+    {
+      type: "metrics",
+      measure: "count",
+      metrics: [
+        { name: "cr.node.sql.distsql.queries.active", title: "Active Queries" },
+      ],
+    },
+    {
+      type: "nodes",
+      measure: "count",
+      metric: { name: "cr.node.sql.distsql.flows.active" },
+    },
+    {
+      type: "nodes",
+      measure: "duration",
+      metric: { name: "cr.node.sql.service.latency-p99" },
+    },
+    {
+      type: "nodes",
+      measure: "duration",
+      metric: { name: "cr.node.sql.service.latency-p90" },
+    },
+    {
+      type: "nodes",
+      measure: "duration",
+      metric: { name: "cr.node.sql.distsql.service.latency-p99" },
+    },
+    {
+      type: "nodes",
+      measure: "duration",
+      metric: { name: "cr.node.sql.distsql.service.latency-p90" },
+    },
+    {
+      type: "nodes",
+      measure: "duration",
+      metric: { name: "cr.node.exec.latency-p99" },
+    },
+    {
+      type: "nodes",
+      measure: "duration",
+      metric: { name: "cr.node.exec.latency-p90" },
+    },
+    {
+      type: "metrics",
+      measure: "count",
+      metrics: [
+        { name: "cr.node.sql.txn.begin.count", title: "Begin" },
+        { name: "cr.node.sql.txn.commit.count", title: "Commits" },
+        { name: "cr.node.sql.txn.rollback.count", title: "Rollbacks" },
+        { name: "cr.node.sql.txn.abort.count", title: "Aborts" },
+      ],
+    },
+    {
+      type: "metrics",
+      measure: "count",
+      metrics: [
+        { name: "cr.node.sql.ddl.count", title: "DDL Statements" },
+      ],
+    },
+  ],
 };
 
 export default function (props: GraphDashboardProps) {

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
@@ -1,32 +1,39 @@
 import React from "react";
-import _ from "lodash";
 
-import { LineGraph } from "src/views/cluster/components/linegraph";
-import { Metric, Axis, AxisUnits } from "src/views/shared/components/metricQuery";
-import { DashboardConfig } from "src/util/charts";
+import { AxisUnits } from "src/views/shared/components/metricQuery";
+import { DashboardConfigState } from "src/util/charts";
 
-import { GraphDashboardProps, nodeAddress } from "./dashboardUtils";
+import { nodeAddress } from "./dashboardUtils";
 
-export const charts: DashboardConfig = {
+const charts: DashboardConfigState = ({ nodeIDs, nodesSummary, nodeSources, tooltipSelection }) => ({
   id: "nodes.sql",
+  name: "SQL",
   charts: [
     {
-      type: "metrics",
+      title: "SQL Connections",
+      sources: nodeSources,
+      tooltip: `The total number of active SQL connections ${tooltipSelection}.`,
       measure: "count",
       metrics: [
-        { name: "cr.node.sql.conns", title: "Client Connections" },
+        { title: "Client Connections", name: "cr.node.sql.conns" },
       ],
     },
     {
-      type: "metrics",
-      measure: "bytes",
+      title: "SQL Byte Traffic",
+      sources: nodeSources,
+      tooltip: `The total amount of SQL client network traffic in bytes per second ${tooltipSelection}.`,
+      axis: { units: AxisUnits.Bytes, label: "byte traffic" },
+      measure: "count",
       metrics: [
-        { name: "cr.node.sql.bytesin", title: "Bytes In" },
-        { name: "cr.node.sql.bytesout", title: "Bytes Out" },
+        { name: "cr.node.sql.bytesin", title: "Bytes In", nonNegativeRate: true },
+        { name: "cr.node.sql.bytesout", title: "Bytes Out", nonNegativeRate: true },
       ],
     },
     {
-      type: "metrics",
+      title: "SQL Queries",
+      sources: nodeSources,
+      tooltip: `A ten-second moving average of the # of SELECT, INSERT, UPDATE, and DELETE operations
+        started per second ${tooltipSelection}.`,
       measure: "count",
       metrics: [
         { name: "cr.node.sql.select.count", title: "Total Reads" },
@@ -37,49 +44,115 @@ export const charts: DashboardConfig = {
       ],
     },
     {
-      type: "metrics",
+      title: "Active Distributed SQL Queries",
+      sources: nodeSources,
+      tooltip: `The total number of distributed SQL queries currently running ${tooltipSelection}.`,
       measure: "count",
       metrics: [
         { name: "cr.node.sql.distsql.queries.active", title: "Active Queries" },
       ],
     },
     {
-      type: "nodes",
+      title: "Active Flows for Distributed SQL Queries",
+      tooltip: "The number of flows on each node contributing to currently running distributed SQL queries.",
       measure: "count",
-      metric: { name: "cr.node.sql.distsql.flows.active" },
+      metrics: nodeIDs.map((node) => (
+        { name: "cr.node.sql.distsql.flows.active", title: nodeAddress(nodesSummary, node), sources: [node] }
+      )),
+    },
+    // TODO(vilterp): maybe we should be able to just say that this is a node chart
+    // instead of explicitly mapping over the list of node ids here
+    {
+      title: "Service Latency: SQL, 99th percentile",
+      tooltip: (
+        <div>
+          Over the last minute, this node executed 99% of queries within this time.&nbsp;
+          <em>This time does not include network latency between the node and client.</em>
+        </div>
+      ),
+      axis: { units: AxisUnits.Duration },
+      measure: "duration", // TODO(vilterp): figure out how to dedup measure vs units
+      metrics: nodeIDs.map((node) => ({
+        name: "cr.node.sql.service.latency-p99",
+        title: nodeAddress(nodesSummary, node),
+        sources: [node],
+        downsampleMax: true,
+      })),
     },
     {
-      type: "nodes",
+      title: "Service Latency: SQL, 90th percentile",
+      tooltip: (
+        <div>
+          Over the last minute, this node executed 90% of queries within this time.&nbsp;
+          <em>This time does not include network latency between the node and client.</em>
+        </div>
+      ),
+      axis: { units: AxisUnits.Duration },
+      measure: "duration", // TODO(vilterp): figure out how to dedup measure vs units
+      metrics: nodeIDs.map((node) => ({
+        name: "cr.node.sql.service.latency-p90",
+        title: nodeAddress(nodesSummary, node),
+        sources: [node],
+        downsampleMax: true,
+      })),
+    },
+    {
+      title: "Service Latency: DistSQL, 99th percentile",
+      tooltip: `The latency of distributed SQL statements serviced over
+                  10 second periods ${tooltipSelection}.`,
+      axis: { units: AxisUnits.Duration },
       measure: "duration",
-      metric: { name: "cr.node.sql.service.latency-p99" },
+      metrics: nodeIDs.map((node) => ({
+        name: "cr.node.sql.distsql.service.latency-p99",
+        title: nodeAddress(nodesSummary, node),
+        sources: [node],
+        downsampleMax: true,
+      })),
     },
     {
-      type: "nodes",
+      title: "Service Latency: DistSQL, 90th percentile",
+      tooltip: `The latency of distributed SQL statements serviced over
+                  10 second periods ${tooltipSelection}.`,
+      axis: { units: AxisUnits.Duration },
       measure: "duration",
-      metric: { name: "cr.node.sql.service.latency-p90" },
+      metrics: nodeIDs.map((node) => ({
+        name: "cr.node.sql.distsql.service.latency-p90",
+        title: nodeAddress(nodesSummary, node),
+        sources: [node],
+        downsampleMax: true,
+      })),
     },
     {
-      type: "nodes",
+      title: "Execution Latency: 99th percentile",
+      tooltip: `The 99th percentile of latency between query requests and responses over a
+          1 minute period. Values are displayed individually for each node on each node.`,
+      axis: { units: AxisUnits.Duration },
       measure: "duration",
-      metric: { name: "cr.node.sql.distsql.service.latency-p99" },
+      metrics: nodeIDs.map((node) => ({
+        name: "cr.node.exec.latency-p99",
+        title: nodeAddress(nodesSummary, node),
+        sources: [node],
+        downsampleMax: true,
+      })),
     },
     {
-      type: "nodes",
+      title: "Execution Latency: 90th percentile",
+      tooltip: `The 90th percentile of latency between query requests and responses over a
+          1 minute period. Values are displayed individually for each node on each node.`,
+      axis: { units: AxisUnits.Duration },
       measure: "duration",
-      metric: { name: "cr.node.sql.distsql.service.latency-p90" },
+      metrics: nodeIDs.map((node) => ({
+        name: "cr.node.exec.latency-p90",
+        title: nodeAddress(nodesSummary, node),
+        sources: [node],
+        downsampleMax: true,
+      })),
     },
     {
-      type: "nodes",
-      measure: "duration",
-      metric: { name: "cr.node.exec.latency-p99" },
-    },
-    {
-      type: "nodes",
-      measure: "duration",
-      metric: { name: "cr.node.exec.latency-p90" },
-    },
-    {
-      type: "metrics",
+      title: "Transactions",
+      sources: nodeSources,
+      tooltip: `The total number of transactions opened, committed, rolled back,
+                  or aborted per second ${tooltipSelection}.`,
       measure: "count",
       metrics: [
         { name: "cr.node.sql.txn.begin.count", title: "Begin" },
@@ -89,247 +162,15 @@ export const charts: DashboardConfig = {
       ],
     },
     {
-      type: "metrics",
+      title: "Schema Changes",
+      sources: nodeSources,
+      tooltip: `The total number of DDL statements per second ${tooltipSelection}.`,
       measure: "count",
       metrics: [
         { name: "cr.node.sql.ddl.count", title: "DDL Statements" },
       ],
     },
   ],
-};
+});
 
-export default function (props: GraphDashboardProps) {
-  const { nodeIDs, nodesSummary, nodeSources, tooltipSelection } = props;
-
-  return [
-    <LineGraph
-      title="SQL Connections"
-      sources={nodeSources}
-      tooltip={`The total number of active SQL connections ${tooltipSelection}.`}
-    >
-      <Axis>
-        <Metric name="cr.node.sql.conns" title="Client Connections" />
-      </Axis>
-    </LineGraph>,
-
-    <LineGraph
-      title="SQL Byte Traffic"
-      sources={nodeSources}
-      tooltip={
-        `The total amount of SQL client network traffic in bytes per second ${tooltipSelection}.`
-      }
-    >
-      <Axis units={AxisUnits.Bytes} label="byte traffic">
-        <Metric name="cr.node.sql.bytesin" title="Bytes In" nonNegativeRate />
-        <Metric name="cr.node.sql.bytesout" title="Bytes Out" nonNegativeRate />
-      </Axis>
-    </LineGraph>,
-
-    <LineGraph
-      title="SQL Queries"
-      sources={nodeSources}
-      tooltip={
-        `A ten-second moving average of the # of SELECT, INSERT, UPDATE, and DELETE operations
-        started per second ${tooltipSelection}.`
-      }
-    >
-      <Axis>
-        <Metric name="cr.node.sql.select.count" title="Total Reads" nonNegativeRate />
-        <Metric name="cr.node.sql.distsql.select.count" title="DistSQL Reads" nonNegativeRate />
-        <Metric name="cr.node.sql.update.count" title="Updates" nonNegativeRate />
-        <Metric name="cr.node.sql.insert.count" title="Inserts" nonNegativeRate />
-        <Metric name="cr.node.sql.delete.count" title="Deletes" nonNegativeRate />
-      </Axis>
-    </LineGraph>,
-
-    <LineGraph
-      title="Active Distributed SQL Queries"
-      sources={nodeSources}
-      tooltip={`The total number of distributed SQL queries currently running ${tooltipSelection}.`}
-    >
-      <Axis>
-        <Metric name="cr.node.sql.distsql.queries.active" title="Active Queries" />
-      </Axis>
-    </LineGraph>,
-
-    <LineGraph
-      title="Active Flows for Distributed SQL Queries"
-      tooltip="The number of flows on each node contributing to currently running distributed SQL queries."
-    >
-      <Axis>
-        {
-          _.map(nodeIDs, (node) => (
-            <Metric
-              key={node}
-              name="cr.node.sql.distsql.flows.active"
-              title={nodeAddress(nodesSummary, node)}
-              sources={[node]}
-            />
-          ))
-        }
-      </Axis>
-    </LineGraph>,
-
-    <LineGraph
-      title="Service Latency: SQL, 99th percentile"
-      tooltip={(
-        <div>
-          Over the last minute, this node executed 99% of queries within this time.&nbsp;
-            <em>This time does not include network latency between the node and client.</em>
-        </div>
-      )}
-    >
-      <Axis units={AxisUnits.Duration}>
-        {
-          _.map(nodeIDs, (node) => (
-            <Metric
-              key={node}
-              name="cr.node.sql.service.latency-p99"
-              title={nodeAddress(nodesSummary, node)}
-              sources={[node]}
-              downsampleMax
-            />
-          ))
-        }
-      </Axis>
-    </LineGraph>,
-
-    <LineGraph
-      title="Service Latency: SQL, 90th percentile"
-      tooltip={(
-        <div>
-          Over the last minute, this node executed 90% of queries within this time.&nbsp;
-            <em>This time does not include network latency between the node and client.</em>
-        </div>
-      )}
-    >
-      <Axis units={AxisUnits.Duration}>
-        {
-          _.map(nodeIDs, (node) => (
-            <Metric
-              key={node}
-              name="cr.node.sql.service.latency-p90"
-              title={nodeAddress(nodesSummary, node)}
-              sources={[node]}
-              downsampleMax
-            />
-          ))
-        }
-      </Axis>
-    </LineGraph>,
-
-    <LineGraph
-      title="Service Latency: DistSQL, 99th percentile"
-      tooltip={
-        `The latency of distributed SQL statements serviced over
-           10 second periods ${tooltipSelection}.`
-      }
-    >
-      <Axis units={AxisUnits.Duration}>
-        {
-          _.map(nodeIDs, (node) => (
-            <Metric
-              key={node}
-              name="cr.node.sql.distsql.service.latency-p99"
-              title={nodeAddress(nodesSummary, node)}
-              sources={[node]}
-              downsampleMax
-            />
-          ))
-        }
-      </Axis>
-    </LineGraph>,
-
-    <LineGraph
-      title="Service Latency: DistSQL, 90th percentile"
-      tooltip={
-        `The latency of distributed SQL statements serviced over
-           10 second periods ${tooltipSelection}.`
-      }
-    >
-      <Axis units={AxisUnits.Duration}>
-        {
-          _.map(nodeIDs, (node) => (
-            <Metric
-              key={node}
-              name="cr.node.sql.distsql.service.latency-p90"
-              title={nodeAddress(nodesSummary, node)}
-              sources={[node]}
-              downsampleMax
-            />
-          ))
-        }
-      </Axis>
-    </LineGraph>,
-
-    <LineGraph
-      title="Execution Latency: 99th percentile"
-      tooltip={
-        `The 99th percentile of latency between query requests and responses over a
-          1 minute period. Values are displayed individually for each node on each node.`
-      }
-    >
-      <Axis units={AxisUnits.Duration}>
-        {
-          _.map(nodeIDs, (node) => (
-            <Metric
-              key={node}
-              name="cr.node.exec.latency-p99"
-              title={nodeAddress(nodesSummary, node)}
-              sources={[node]}
-              downsampleMax
-            />
-          ))
-        }
-      </Axis>
-    </LineGraph>,
-
-    <LineGraph
-      title="Execution Latency: 90th percentile"
-      tooltip={
-        `The 90th percentile of latency between query requests and responses over a
-           1 minute period. Values are displayed individually for each node on each node.`
-      }
-    >
-      <Axis units={AxisUnits.Duration}>
-        {
-          _.map(nodeIDs, (node) => (
-            <Metric
-              key={node}
-              name="cr.node.exec.latency-p90"
-              title={nodeAddress(nodesSummary, node)}
-              sources={[node]}
-              downsampleMax
-            />
-          ))
-        }
-      </Axis>
-    </LineGraph>,
-
-    <LineGraph
-      title="Transactions"
-      sources={nodeSources}
-      tooltip={
-        `The total number of transactions opened, committed, rolled back,
-           or aborted per second ${tooltipSelection}.`
-      }
-    >
-      <Axis>
-        <Metric name="cr.node.sql.txn.begin.count" title="Begin" nonNegativeRate />
-        <Metric name="cr.node.sql.txn.commit.count" title="Commits" nonNegativeRate />
-        <Metric name="cr.node.sql.txn.rollback.count" title="Rollbacks" nonNegativeRate />
-        <Metric name="cr.node.sql.txn.abort.count" title="Aborts" nonNegativeRate />
-      </Axis>
-    </LineGraph>,
-
-    <LineGraph
-      title="Schema Changes"
-      sources={nodeSources}
-      tooltip={`The total number of DDL statements per second ${tooltipSelection}.`}
-    >
-      <Axis>
-        <Metric name="cr.node.sql.ddl.count" title="DDL Statements" nonNegativeRate />
-      </Axis>
-    </LineGraph>,
-  ];
-}
+export default charts;

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
@@ -3,60 +3,63 @@ import _ from "lodash";
 
 import { LineGraph } from "src/views/cluster/components/linegraph";
 import { Metric, Axis, AxisUnits } from "src/views/shared/components/metricQuery";
-import { ChartConfig } from "src/util/charts";
+import { DashboardConfig } from "src/util/charts";
 
 import { GraphDashboardProps, nodeAddress, storeIDsForNode } from "./dashboardUtils";
 
-export const charts: ChartConfig = {
-  "nodes.storage.0": {
-    type: "metrics",
-    measure: "bytes",
-    metrics: [
-      { name: "cr.store.capacity", title: "Capacity" },
-      { name: "cr.store.capacity.available", title: "Available" },
-      { name: "cr.store.capacity.used", title: "Used" },
-    ],
-  },
-  "nodes.storage.1": {
-    type: "metrics",
-    measure: "bytes",
-    metrics: [
-      { name: "cr.store.livebytes", title: "Live" },
-      { name: "cr.store.sysbytes", title: "System" },
-    ],
-  },
-  "nodes.storage.2": {
-    type: "nodes",
-    measure: "duration",
-    metric: { name: "cr.store.raft.process.logcommit.latency-p99" },
-  },
-  "nodes.storage.3": {
-    type: "nodes",
-    measure: "duration",
-    metric: { name: "cr.store.raft.process.commandcommit.latency-p99" },
-  },
-  "nodes.storage.4": {
-    type: "metrics",
-    measure: "count",
-    metrics: [
-      { name: "cr.store.rocksdb.read-amplification", title: "Read Amplification" },
-    ],
-  },
-  "nodes.storage.5": {
-    type: "metrics",
-    measure: "count",
-    metrics: [
-      { name: "cr.store.rocksdb.num-sstables", title: "SSTables" },
-    ],
-  },
-  "nodes.storage.6": {
-    type: "metrics",
-    measure: "count",
-    metrics: [
-      { name: "cr.node.sys.fd.open", title: "Open" },
-      { name: "cr.node.sys.fd.softlimit", title: "Limit" },
-    ],
-  },
+export const charts: DashboardConfig = {
+  id: "nodes.storage",
+  charts: [
+    {
+      type: "metrics",
+      measure: "bytes",
+      metrics: [
+        { name: "cr.store.capacity", title: "Capacity" },
+        { name: "cr.store.capacity.available", title: "Available" },
+        { name: "cr.store.capacity.used", title: "Used" },
+      ],
+    },
+    {
+      type: "metrics",
+      measure: "bytes",
+      metrics: [
+        { name: "cr.store.livebytes", title: "Live" },
+        { name: "cr.store.sysbytes", title: "System" },
+      ],
+    },
+    {
+      type: "nodes",
+      measure: "duration",
+      metric: { name: "cr.store.raft.process.logcommit.latency-p99" },
+    },
+    {
+      type: "nodes",
+      measure: "duration",
+      metric: { name: "cr.store.raft.process.commandcommit.latency-p99" },
+    },
+    {
+      type: "metrics",
+      measure: "count",
+      metrics: [
+        { name: "cr.store.rocksdb.read-amplification", title: "Read Amplification" },
+      ],
+    },
+    {
+      type: "metrics",
+      measure: "count",
+      metrics: [
+        { name: "cr.store.rocksdb.num-sstables", title: "SSTables" },
+      ],
+    },
+    {
+      type: "metrics",
+      measure: "count",
+      metrics: [
+        { name: "cr.node.sys.fd.open", title: "Open" },
+        { name: "cr.node.sys.fd.softlimit", title: "Limit" },
+      ],
+    },
+  ],
 };
 
 export default function (props: GraphDashboardProps) {

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/index.tsx
@@ -186,15 +186,11 @@ class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
         <div key={key}>
           <MetricsDataProvider id={key}>
             <LineGraph
-              title={chartConfig.title}
-              sources={chartConfig.sources}
-              tooltip={chartConfig.tooltip}
+              config={chartConfig}
               hoverOn={hoverOn}
               hoverOff={hoverOff}
               hoverState={hoverState}
               chartKey={key}
-              axis={chartConfig.axis || {}}
-              metrics={metrics}
             />
           </MetricsDataProvider>
         </div>

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/index.tsx
@@ -26,29 +26,26 @@ import {
   GraphDashboardProps, storeIDsForNode,
 } from "./dashboards/dashboardUtils";
 
-import overviewDashboard from "./dashboards/overview";
-import runtimeDashboard from "./dashboards/runtime";
+// import overviewDashboard from "./dashboards/overview";
+// import runtimeDashboard from "./dashboards/runtime";
 import sqlDashboard from "./dashboards/sql";
-import storageDashboard from "./dashboards/storage";
-import replicationDashboard from "./dashboards/replication";
-import distributedDashboard from "./dashboards/distributed";
-import queuesDashboard from "./dashboards/queues";
-import requestsDashboard from "./dashboards/requests";
+// import storageDashboard from "./dashboards/storage";
+// import replicationDashboard from "./dashboards/replication";
+// import distributedDashboard from "./dashboards/distributed";
+// import queuesDashboard from "./dashboards/queues";
+// import requestsDashboard from "./dashboards/requests";
+import {DashboardConfigState} from "oss/src/util/charts";
+import {LineGraph} from "oss/src/views/cluster/components/linegraph";
 
-interface GraphDashboard {
-  label: string;
-  component: (props: GraphDashboardProps) => React.ReactElement<any>[];
-}
-
-const dashboards: {[key: string]: GraphDashboard} = {
-  "overview" : { label: "Overview", component: overviewDashboard },
-  "runtime" : { label: "Runtime", component: runtimeDashboard },
-  "sql": { label: "SQL", component: sqlDashboard },
-  "storage": { label: "Storage", component: storageDashboard },
-  "replication": { label: "Replication", component: replicationDashboard },
-  "distributed": { label: "Distributed", component: distributedDashboard },
-  "queues": { label: "Queues", component: queuesDashboard },
-  "requests": { label: "Slow Requests", component: requestsDashboard},
+const dashboards: {[key: string]: DashboardConfigState} = {
+  // "overview" : { label: "Overview", component: overviewDashboard },
+  // "runtime" : { label: "Runtime", component: runtimeDashboard },
+  "sql": sqlDashboard,
+  // "storage": { label: "Storage", component: storageDashboard },
+  // "replication": { label: "Replication", component: replicationDashboard },
+  // "distributed": { label: "Distributed", component: distributedDashboard },
+  // "queues": { label: "Queues", component: queuesDashboard },
+  // "requests": { label: "Slow Requests", component: requestsDashboard},
 };
 
 const defaultDashboard = "overview";
@@ -56,7 +53,7 @@ const defaultDashboard = "overview";
 const dashboardDropdownOptions = _.map(dashboards, (dashboard, key) => {
   return {
     value: key,
-    label: dashboard.label,
+    label: dashboard.name,
   };
 });
 
@@ -179,13 +176,26 @@ class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
 
     // Generate graphs for the current dashboard, wrapping each one in a
     // MetricsDataProvider with a unique key.
-    const graphs = dashboards[dashboard].component(dashboardProps);
-    const graphComponents = _.map(graphs, (graph, idx) => {
+    const dashboardConfig = dashboards[dashboard](dashboardProps);
+    const graphComponents = dashboardConfig.charts.map((chartConfig, idx) => {
       const key = `nodes.${dashboard}.${idx}`;
+      const metrics = chartConfig.metric
+        ? [chartConfig.metric]
+        : chartConfig.metrics;
       return (
         <div key={key}>
           <MetricsDataProvider id={key}>
-            { React.cloneElement(graph, { hoverOn, hoverOff, hoverState, chartKey: key }) }
+            <LineGraph
+              title={chartConfig.title}
+              sources={chartConfig.sources}
+              tooltip={chartConfig.tooltip}
+              hoverOn={hoverOn}
+              hoverOff={hoverOff}
+              hoverState={hoverState}
+              chartKey={key}
+              axis={chartConfig.axis || {}}
+              metrics={metrics}
+            />
           </MetricsDataProvider>
         </div>
       );

--- a/pkg/ui/src/views/cluster/util/graphs.ts
+++ b/pkg/ui/src/views/cluster/util/graphs.ts
@@ -1,4 +1,3 @@
-import React from "react";
 import _ from "lodash";
 import * as nvd3 from "nvd3";
 import * as d3 from "d3";
@@ -9,8 +8,9 @@ import { NanoToMilli } from "src/util/convert";
 import { ComputePrefixExponent, ComputeByteScale } from "src/util/format";
 
 import {
-  MetricProps, AxisProps, AxisUnits, QueryTimeInfo,
+  AxisUnits, QueryTimeInfo,
 } from "src/views/shared/components/metricQuery";
+import {AxisConfig, Metric} from "oss/src/util/charts";
 
 type TSResponse = protos.cockroach.ts.tspb.TimeSeriesQueryResponse;
 
@@ -237,7 +237,7 @@ type formattedSeries = {
 };
 
 function formatMetricData(
-  metrics: React.ReactElement<MetricProps>[],
+  metrics: Metric[],
   data: TSResponse,
 ): formattedSeries[] {
   const formattedData: formattedSeries[] = [];
@@ -247,7 +247,7 @@ function formatMetricData(
     if (result) {
       formattedData.push({
         values: result.datapoints,
-        key: s.props.title || s.props.name,
+        key: s.title || s.name,
         area: true,
         fillOpacity: 0.1,
         disableTooltip: true,
@@ -280,8 +280,8 @@ export function InitLineChart(chart: nvd3.LineChart) {
 export function ConfigureLineChart(
   chart: nvd3.LineChart,
   svgEl: SVGElement,
-  metrics: React.ReactElement<MetricProps>[],
-  axis: React.ReactElement<AxisProps>,
+  metrics: Metric[],
+  axis: AxisConfig,
   data: TSResponse,
   timeInfo: QueryTimeInfo,
   hoverTime?: moment.Moment,
@@ -295,11 +295,11 @@ export function ConfigureLineChart(
     formattedData = formatMetricData(metrics, data);
 
     xAxisDomain = calculateXAxisDomain(timeInfo);
-    yAxisDomain = calculateYAxisDomain(axis.props.units, data);
+    yAxisDomain = calculateYAxisDomain(axis.units, data);
 
     chart.yDomain(yAxisDomain.extent);
-    if (axis.props.label) {
-      chart.yAxis.axisLabel(`${axis.props.label} (${yAxisDomain.label})`);
+    if (axis.label) {
+      chart.yAxis.axisLabel(`${axis.label} (${yAxisDomain.label})`);
     } else {
       chart.yAxis.axisLabel(yAxisDomain.label);
     }

--- a/pkg/ui/src/views/shared/components/metricQuery/index.tsx
+++ b/pkg/ui/src/views/shared/components/metricQuery/index.tsx
@@ -44,64 +44,6 @@ export enum AxisUnits {
 }
 
 /**
- * AxisProps represents the properties of an Axis being specified as part of a
- * query for metrics.
- */
-export interface AxisProps {
-  label?: string;
-  format?: (n: number) => string;
-  range?: number[];
-  units?: AxisUnits;
-}
-
-/**
- * Axis is a React component which describes an Axis of a metrics query.
- *
- * This component should not be rendered directly; rather, a renderable
- * component should contain axes as children and use them only informationally
- * without rendering them.
- */
-export class Axis extends React.Component<AxisProps, {}> {
-  static defaultProps: AxisProps = {
-    units: AxisUnits.Count,
-  };
-
-  render(): React.ReactElement<any> {
-    throw new Error("Component <Axis /> should never render.");
-  }
-}
-
-/**
- * MetricProps reperesents the properties of a Metric being selected as part of
- * a query.
- */
-export interface MetricProps {
-  name: string;
-  sources?: string[];
-  title?: string;
-  rate?: boolean;
-  nonNegativeRate?: boolean;
-  aggregateMax?: boolean;
-  aggregateMin?: boolean;
-  aggregateAvg?: boolean;
-  downsampleMax?: boolean;
-  downsampleMin?: boolean;
-}
-
-/**
- * Metric is a React component which describes a Metric in a metrics query.
- *
- * This component should not be rendered directly; rather, a renderable
- * component should contain axes as children and use them only informationally
- * without rendering them.
- */
-export class Metric extends React.Component<MetricProps, {}> {
-  render(): React.ReactElement<any> {
-    throw new Error("Component <Metric /> should never render.");
-  }
-}
-
-/**
  * QueryTimeInfo is a convenience structure which contains information about
  * the time range of a metrics query.
  */


### PR DESCRIPTION
An attempt to power both the tooltip and chart rendering from the same data structure.

May throw away this branch and try a different approach; just keeping it here for reference. cc @couchand 

Notes:
- Overall, try to make the config more static. If functions are needed, put them at the individual chart level, instead of the whole thing being a function.
  - A blocker for this is tooltips, which depend on selection status (single node vs. cluster).
- Get rid of the `nodeId.map(...)`s. Instead just declare something a "node" or a "metric" chart and do those automatically. On a design note, might be good to make those visually distinct as well. (little icons or something?)

Overview thoughts:
- Things that have to come together to render:
  - Config (which metrics; currently hardcoded per dashboard but could be editable in future)
  - Selection state (cluster vs node. User can change this at runtime)
  - TS data (updated every 10s)
  - Time selection (User can change at runtime)
- These are output to:
  - Tooltip
  - Charts